### PR TITLE
#84 service timeout when checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+### Fixed
+- *[#84](https://github.com/idealista/consul_role/issues/84) service check timeout in healthcheck* @blalop
 
-### Added
+
 ## [1.9.0](https://github.com/idealista/consul_role/tree/1.9.0) (2022-09-26)
 ### [Full Changelog](https://github.com/idealista/consul_role/compare/1.8.0...1.9.0)
+### Added
 - *[#84](https://github.com/idealista/consul_role/issues/84) Added service check timeout support* @blalop
 
 ## [1.8.0](https://github.com/idealista/consul_role/tree/1.8.0) (2021-12-23)

--- a/molecule/default/group_vars/agent.yml
+++ b/molecule/default/group_vars/agent.yml
@@ -15,3 +15,4 @@ consul_services_register:
   - name: node exporter script
     script: "pidof node_exporter"
     interval: "60s"
+    timeout: 1

--- a/tasks/service_healthcheck.yml
+++ b/tasks/service_healthcheck.yml
@@ -7,9 +7,14 @@
 - name: Consul | Check service is healthy
   block:
     - name: Consul | Check that web server is available
+      vars:
+        timeout_unit: "{{ item.timeout[-1] }}"
+        timeout_has_suffix: "{{ timeout_unit in ['s', 'm'] }}"
+        timeout_seconds: "{{ item.timeout[:-1] }}"
+        timeout_minutes: "{{ item.timeout[:-1] | int * 60 }}"
       uri:
         url: "{{ item.http }}"
-        timeout: "{{ (item.timeout[:-1] if item.timeout[-1] == 's' elsif item.timeout[-1] == 'm' item.timeout[:-1] | int * 60 else item.timeout | int * 60) | default(omit) }}"
+        timeout: "{{ (item.timeout if not timeout_has_suffix else (timeout_seconds if timeout_unit == 's' else timeout_minutes)) | default(omit) }}"
         return_content: no
         status_code: 200
       when: "item.http is defined"

--- a/tasks/service_healthcheck.yml
+++ b/tasks/service_healthcheck.yml
@@ -9,7 +9,7 @@
     - name: Consul | Check that web server is available
       uri:
         url: "{{ item.http }}"
-        timeout: "{{ (item.timeout[:-1] if item.timeout[-1] == "s" else 60 * item.timeout[:-1] | int) | default(omit) }}"
+        timeout: "{{ (item.timeout[:-1] if item.timeout[-1] == 's' else 60 * item.timeout[:-1] | int) | default(omit) }}"
         return_content: no
         status_code: 200
       when: "item.http is defined"

--- a/tasks/service_healthcheck.yml
+++ b/tasks/service_healthcheck.yml
@@ -9,7 +9,7 @@
     - name: Consul | Check that web server is available
       uri:
         url: "{{ item.http }}"
-        timeout: "{{ (item.timeout[:-1] if item.timeout[-1] == 's' else 60 * item.timeout[:-1] | int) | default(omit) }}"
+        timeout: "{{ (item.timeout[:-1] if item.timeout[-1] == 's' elsif item.timeout[-1] == 's' item.timeout[:-1] | int * 60 else item.timeout | int * 60) | default(omit) }}"
         return_content: no
         status_code: 200
       when: "item.http is defined"

--- a/tasks/service_healthcheck.yml
+++ b/tasks/service_healthcheck.yml
@@ -9,6 +9,7 @@
     - name: Consul | Check that web server is available
       uri:
         url: "{{ item.http }}"
+        timeout: "{{ item.timeout | default (omit) }}"
         return_content: no
         status_code: 200
       when: "item.http is defined"

--- a/tasks/service_healthcheck.yml
+++ b/tasks/service_healthcheck.yml
@@ -9,7 +9,7 @@
     - name: Consul | Check that web server is available
       uri:
         url: "{{ item.http }}"
-        timeout: "{{ (item.timeout[:-1] if item.timeout[-1] == 's' elsif item.timeout[-1] == 's' item.timeout[:-1] | int * 60 else item.timeout | int * 60) | default(omit) }}"
+        timeout: "{{ (item.timeout[:-1] if item.timeout[-1] == 's' elsif item.timeout[-1] == 'm' item.timeout[:-1] | int * 60 else item.timeout | int * 60) | default(omit) }}"
         return_content: no
         status_code: 200
       when: "item.http is defined"

--- a/tasks/service_healthcheck.yml
+++ b/tasks/service_healthcheck.yml
@@ -9,7 +9,7 @@
     - name: Consul | Check that web server is available
       uri:
         url: "{{ item.http }}"
-        timeout: "{{ item.timeout | default (omit) }}"
+        timeout: "{{ (item.timeout[:-1] if item.timeout[-1] == "s" else 60 * item.timeout[:-1] | int) | default(omit) }}"
         return_content: no
         status_code: 200
       when: "item.http is defined"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

Also support the timeout in the previous healthcheck.


### Benefits

Do not fail if the default timeout of Ansible's uri module of 30 seconds is surpassed

### Possible Drawbacks

N/A

### Applicable Issues

#84 
