### PR TITLE
Bugs/91 install Python dependencies based on the Python interpreter being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## Unreleased
 
+## [1.9.3](https://github.com/idealista/consul_role/tree/1.9.3) (2023-02-22)
+### [Full Changelog](https://github.com/idealista/consul_role/compare/1.9.2...1.9.3)
+### Fixed
+- *[#91](https://github.com/idealista/consul_role/issues/91) install Python dependencies based on the Python interpreter being used* @ommarmol
+
+
 ## [1.9.2](https://github.com/idealista/consul_role/tree/1.9.2) (2022-09-29)
 ### [Full Changelog](https://github.com/idealista/consul_role/compare/1.9.1...1.9.2)
 ### Fixed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,5 +109,5 @@ consul_required_libs:
   - ca-certificates
   - "{{ consul_python_pip }}"
 
-consul_python_interpreter_version: "{{ (ansible_python_interpreter | default('') + discovered_interpreter_python | default('')) | regex_search('python3?$') | regex_replace('^.*?python', 'python') }}"
+consul_python_interpreter_version: "{{ (ansible_python_interpreter | default('') + discovered_interpreter_python | default('')) | regex_search('python3') | ternary('python3', 'python') }}"
 consul_python_pip: "{{ consul_python_interpreter_version }}-pip"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,7 +106,7 @@ consul_acl_python_required_packages:
 consul_required_libs:
   - unzip
   - ca-certificates
-  - "{{ python_pip }}"
+  - "{{ consul_python_pip }}"
 
-python_interpreter_version: "{{ (ansible_python_interpreter | default('') + discovered_interpreter_python | default('')) | regex_search('python3?$') | regex_replace('^.*?python', 'python') }}"
-python_pip: "{{ python_interpreter_version }}-pip"
+consul_python_interpreter_version: "{{ (ansible_python_interpreter | default('') + discovered_interpreter_python | default('')) | regex_search('python3?$') | regex_replace('^.*?python', 'python') }}"
+consul_python_pip: "{{ consul_python_interpreter_version }}-pip"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,5 +108,5 @@ consul_required_libs:
   - ca-certificates
   - "{{ python_pip }}"
 
-python_interpreter_version: "{{ (ansible_python_interpreter | default('') + discovered_interpreter_python | default('') ) | regex_search('python3?$') | regex_replace('^.*?python','python') }}"
+python_interpreter_version: "{{ (ansible_python_interpreter | default('') + discovered_interpreter_python | default('')) | regex_search('python3?$') | regex_replace('^.*?python', 'python') }}"
 python_pip: "{{ python_interpreter_version }}-pip"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,3 +102,11 @@ consul_acl_required_libs:
 consul_acl_python_required_packages:
   - pyhcl
   - requests
+
+consul_required_libs:
+  - unzip
+  - ca-certificates
+  - "{{ python_pip }}"
+
+python_interpreter_version: "{{ (ansible_python_interpreter | default('') + discovered_interpreter_python | default('') ) | regex_search('python3?$') | regex_replace('^.*?python','python') }}"
+python_pip: "{{ python_interpreter_version }}-pip"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,6 +98,7 @@ consul_package: "consul_{{ consul_version }}_linux_amd64.zip"
 
 consul_acl_required_libs:
   - openssl
+  - "{{ consul_python_pip }}"
 
 consul_acl_python_required_packages:
   - pyhcl

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Consul | Define consul_required_libs
-  set_fact:
-    consul_required_libs: "{{ __consul_required_libs }}"
-  when: consul_required_libs is not defined
-  tags:
-    - check
-    - install
-    - configure
-
 - name: Consul | Check
   import_tasks: check.yml
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: Consul | Gather  OS specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-  tags:
-    - check
-    - install
-    - configure
 
 - name: Consul | Define consul_required_libs
   set_fact:

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,5 +1,0 @@
----
-__consul_required_libs:
-  - unzip
-  - ca-certificates
-  - python-pip

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,5 +1,0 @@
----
-__consul_required_libs:
-  - unzip
-  - ca-certificates
-  - python3-pip

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,5 +1,0 @@
----
-__consul_required_libs:
-  - unzip
-  - ca-certificates
-  - python-pip


### PR DESCRIPTION
### Description of the Change

A new mechanism has been added for installing OS-specific Python apt packages. This eliminates the need for loading OS-specific variables from files under the "vars" directory, which is why those tasks are now suppressed.

### Benefits

Depending on the Python interpreter being used, the role now sets the names of certain Python packages to be installed with apt-get (python-pip and python3-pip) to avoid conflicts when installing Python packages with pip/pip3, which are used later in the same role.

### Possible Drawbacks

N/A

### Applicable Issues

#91 
