### PR TITLE
Bugs/94 fix how python-pip or python3-pip packages are selected to be installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## Unreleased
 
+## [1.9.4](https://github.com/idealista/consul_role/tree/1.9.4) (2023-05-24)
+### [Full Changelog](https://github.com/idealista/consul_role/compare/1.9.3...1.9.4)
+### Fixed
+- *[#94](https://github.com/idealista/consul_role/issues/94) select pip installable candidate (python-pip or python3-pip) based on ansible_python.version.major fact* @ommarmol
+- *update Dockerfiles to get working repos of archived Debian distros* @ommarmol
+
 ## [1.9.3](https://github.com/idealista/consul_role/tree/1.9.3) (2023-02-22)
 ### [Full Changelog](https://github.com/idealista/consul_role/compare/1.9.2...1.9.3)
 ### Fixed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,5 +109,4 @@ consul_required_libs:
   - ca-certificates
   - "{{ consul_python_pip }}"
 
-consul_python_interpreter_version: "{{ (ansible_python_interpreter | default('') + discovered_interpreter_python | default('')) | regex_search('python3') | ternary('python3', 'python') }}"
-consul_python_pip: "{{ consul_python_interpreter_version }}-pip"
+consul_python_pip: "{{ (ansible_python.version.major | int == 3) | ternary('python3', 'python') }}-pip"

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -7,15 +7,27 @@ FROM {{ item.image }}
 {% endif %}
 
 # install minimal packages for debian slim images
-{% if item.image == 'debian:bullseye-slim' %}
-RUN apt-get update && \
-    apt-get install -y python3 sudo bash ca-certificates iproute2 systemd systemd-sysv python3-pip && \
-    apt-get clean
+{% set python = "python" %}
+{% if item.image is regex('stretch') %}
+    {% set distro = "stretch" %}
+{% elif item.image is regex('bullseye') %}
+    {% set python = "python3" %}
+{% endif %}
+
+{% if distro is defined %}
+RUN rm /etc/apt/sources.list.d/* || true
+RUN echo "deb http://archive.debian.org/debian/ {{ distro }} main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ {{ distro }} main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security {{ distro }}/updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian-security {{ distro }}/updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
 {% else %}
 RUN apt-get update && \
-    apt-get install -y python sudo bash ca-certificates iproute2 systemd systemd-sysv python-pip && \
-    apt-get clean
 {% endif %}
+    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv {{ python }}-pip && \
+    apt-get clean
 
 # https://github.com/moby/moby/issues/28614#issuecomment-310581026
 STOPSIGNAL SIGRTMIN+3

--- a/molecule/sanity_healthcheck/Dockerfile.j2
+++ b/molecule/sanity_healthcheck/Dockerfile.j2
@@ -7,15 +7,27 @@ FROM {{ item.image }}
 {% endif %}
 
 # install minimal packages for debian slim images
-{% if item.image == 'debian:bullseye-slim' %}
-RUN apt-get update && \
-    apt-get install -y python3 sudo bash ca-certificates iproute2 systemd systemd-sysv python3-pip && \
-    apt-get clean
+{% set python = "python" %}
+{% if item.image is regex('stretch') %}
+    {% set distro = "stretch" %}
+{% elif item.image is regex('bullseye') %}
+    {% set python = "python3" %}
+{% endif %}
+
+{% if distro is defined %}
+RUN rm /etc/apt/sources.list.d/* || true
+RUN echo "deb http://archive.debian.org/debian/ {{ distro }} main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ {{ distro }} main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security {{ distro }}/updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian-security {{ distro }}/updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
 {% else %}
 RUN apt-get update && \
-    apt-get install -y python sudo bash ca-certificates iproute2 systemd systemd-sysv python-pip && \
-    apt-get clean
 {% endif %}
+    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv {{ python }}-pip && \
+    apt-get clean
 
 # https://github.com/moby/moby/issues/28614#issuecomment-310581026
 STOPSIGNAL SIGRTMIN+3


### PR DESCRIPTION
### Description of the Change

Instead of using `ansible_python_interpreter` and `discovered_interpreter_python` variables to figure out which version of Python is used by Ansible, the fact `ansible_python.version.major` is used instead as it proved to be more accurate and less prone to errors.


### Benefits

The bug is now fixed and the role works in previous failing scenarios.

### Possible Drawbacks

N/A

### Applicable Issues

#94
