### PR TITLE
Bug/101 fix error installing python dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+### Fixed
+- *[#101](https://github.com/idealista/consul_role/issues/101) add python-pip/python3-pip as required dependency* @ommarmol
 
 ## [1.10.0](https://github.com/idealista/consul_role/tree/1.10.0) (2024-05-07)
 ### [Full Changelog](https://github.com/idealista/consul_role/compare/1.9.4...1.10.0)

--- a/Pipfile
+++ b/Pipfile
@@ -16,4 +16,4 @@ rich = "==12.5.1"
 [dev-packages]
 
 [requires]
-python_version = "3"
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3"
+            "python_version": "3.9"
         },
         "sources": [
             {

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,6 +107,7 @@ consul_acl_python_required_packages:
 consul_required_libs:
   - unzip
   - ca-certificates
+  - "{{ consul_python_bin }}-pip"
 
 consul_virtualenv_required_libs:
   - "{{ consul_python_bin }}-virtualenv"

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -26,7 +26,7 @@ RUN echo "deb http://archive.debian.org/debian/ {{ distro }} main contrib non-fr
 {% else %}
 RUN apt-get update && \
 {% endif %}
-    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv {{ python }}-pip && \
+    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv && \
     apt-get clean
 
 # https://github.com/moby/moby/issues/28614#issuecomment-310581026

--- a/molecule/sanity_healthcheck/Dockerfile.j2
+++ b/molecule/sanity_healthcheck/Dockerfile.j2
@@ -26,7 +26,7 @@ RUN echo "deb http://archive.debian.org/debian/ {{ distro }} main contrib non-fr
 {% else %}
 RUN apt-get update && \
 {% endif %}
-    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv {{ python }}-pip && \
+    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv && \
     apt-get clean
 
 # https://github.com/moby/moby/issues/28614#issuecomment-310581026


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

The package python-pip/python3-pip is added to variable `consul_required_libs` as required dependency.


### Benefits

Now, the role installs python-pip/python3-pip if it is not installed and hence ends with no error.

### Possible Drawbacks

N/A

### Applicable Issues

#101 
