### PR TITLE
Bug/106 Remove virtualenvs by installing some Python dependencies via APT

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,7 @@
-exclude_paths:
+---
 
-- ./molecule
-- ./tasks/consul_acl_ansible_10.yml
+exclude_paths:
+  - ./molecule
 parseable: true
 use_default_rules: true
 verbosity: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo systemctl restart docker
 jobs:
   include:
-  - &python-3.9
+  - &python-3_9
     python: 3.9
     install:
       - pip install pipenv
@@ -17,23 +17,23 @@ jobs:
       - pipenv install -r test-requirements-python-9.txt --skip-lock
     env:
       - MOLECULE_DISTRO=debian:bookworm-slim
-  - <<: *python-3.9
+  - <<: *python-3_9
     env:
       - MOLECULE_DISTRO=debian:bullseye-slim
-  - <<: *python-3.9
+  - <<: *python-3_9
     env:
       - MOLECULE_DISTRO=debian:buster-slim
-  - <<: *python-3.9
+  - <<: *python-3_9
     env:
       - MOLECULE_DISTRO=debian:stretch-slim
-  - &python-3.12
+  - &python-3_12
     python: 3.12
     install:
       - pip install -I pipenv
       - pipenv sync
     env:
       - MOLECULE_DISTRO=debian:bookworm-slim
-  - <<: *python-3.12
+  - <<: *python-3_12
     env:
       - MOLECULE_DISTRO=debian:bullseye-slim
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,34 +9,33 @@ before_install:
   - sudo systemctl restart docker
 jobs:
   include:
-  - python: 3.9
-    env:
-      - MOLECULE_DISTRO=debian:buster-slim
+  - &python-3.9
+    python: 3.9
     install:
       - pip install pipenv
       - rm Pipfile
       - pipenv install -r test-requirements-python-9.txt --skip-lock
-      - pipenv run ansible-galaxy collection install community.general
-  - python: 3.9
-    env:
-      - MOLECULE_DISTRO=debian:stretch-slim
-    install:
-      - pip install pipenv
-      - rm Pipfile
-      - pipenv install -r test-requirements-python-9.txt --skip-lock
-      - pipenv run ansible-galaxy collection install community.general
-  - python: 3.12
     env:
       - MOLECULE_DISTRO=debian:bookworm-slim
-    install:
-      - pip install -I pipenv
-      - pipenv sync
-  - python: 3.12
+  - <<: *python-3.9
     env:
       - MOLECULE_DISTRO=debian:bullseye-slim
+  - <<: *python-3.9
+    env:
+      - MOLECULE_DISTRO=debian:buster-slim
+  - <<: *python-3.9
+    env:
+      - MOLECULE_DISTRO=debian:stretch-slim
+  - &python-3.12
+    python: 3.12
     install:
       - pip install -I pipenv
       - pipenv sync
+    env:
+      - MOLECULE_DISTRO=debian:bookworm-slim
+  - <<: *python-3.12
+    env:
+      - MOLECULE_DISTRO=debian:bullseye-slim
 script:
   - pipenv run molecule test --all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ jobs:
     install:
       - pip install -I pipenv
       - pipenv sync
+      - pipenv run ansible-lint .
+      - pipenv run yamllint .
     env:
       - MOLECULE_DISTRO=debian:bookworm-slim
   - <<: *python-3_12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Changed
 - *[#104](https://github.com/idealista/consul_role/issues/104) Maintain compatibility with legacy consul ACLs* @ultraheroe
 ### Fixed
-- *[#106](https://github.com/idealista/consul_role/issues/106) Remove virtualenvs by installing some Python dependencies via APT * @ommarmol
+- *[#106](https://github.com/idealista/consul_role/issues/106) Remove virtualenvs by installing some Python dependencies via APT* @ommarmol
 ### Deprecated
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## Unreleased
 
-## [1.11.0](https://github.com/idealista/consul_role/tree/1.11.0) (2025-03-10)
+## [1.11.0](https://github.com/idealista/consul_role/tree/1.11.0) (2025-03-12)
 ### [Full Changelog](https://github.com/idealista/consul_role/compare/1.10.1...1.11.0)
 ### Changed
-- *[#104] (https://github.com/idealista/consul_role/issues/104) Maintain compatibility with legacy consul ACLs* @ultraheroe
+- *[#104](https://github.com/idealista/consul_role/issues/104) Maintain compatibility with legacy consul ACLs* @ultraheroe
 ### Fixed
+- *[#106](https://github.com/idealista/consul_role/issues/106) Remove virtualenvs by installing some Python dependencies via APT * @ommarmol
 ### Deprecated
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Create or add to your roles dependency file (e.g requirements.yml):
 
 ``` yml
 - src: idealista.consul_role
-  version: 1.10.1
+  version: 1.11.0
   name: consul
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -127,29 +127,40 @@ consul_services_register:  # Example:
 #   http: "http://localhost:9100"
 #   interval: "60s"
 
-consul_required_python_libs:
-  - python-consul
-
 consul_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/{{ consul_package }}"
 consul_package: "consul_{{ consul_version }}_linux_amd64.zip"
 
-consul_acl_required_libs:
-  - openssl
-  - "{{ consul_python_bin }}-pip"
-
-consul_acl_python_required_packages:
-  - pyhcl
-  - requests
-
-consul_required_libs:
-  - unzip
-  - ca-certificates
-  - "{{ consul_python_bin }}-pip"
-
-consul_virtualenv_required_libs:
-  - "{{ consul_python_bin }}-virtualenv"
-
 consul_python_bin: "{{ (ansible_python.version.major | int == 3) | ternary('python3', 'python') }}"
-consul_python_virtualenv: "{{ (hostvars[inventory_hostname].ansible_distribution_major_version | int >= 12) | ternary(true, false) }}"  # Set to true for installing and using virtualenvs. Default is true for Debian >= 12
-consul_python_virtualenv_name: idealista_consul_role
-consul_python_virtualenv_path: "{{ ansible_env.HOME }}/.virtualenvs/{{ consul_python_virtualenv_name }}"
+
+consul_apt_required_packages:
+  - "{{ consul_python_bin }}-pip"
+  - ca-certificates
+  - openssl
+  - unzip
+
+consul_python_pip_required_packages: "{{ consul_python_pip_required_packages_by_os[ansible_distribution ~'-' ~ansible_distribution_major_version] }}"
+consul_python_apt_required_packages: "{{ consul_python_apt_required_packages_by_os[ansible_distribution ~'-' ~ansible_distribution_major_version] }}"
+
+consul_python_apt_required_packages_by_os:
+  Debian-12:
+    - "{{ consul_python_bin }}-consul2"
+    - "{{ consul_python_bin }}-pyhcl"
+    - "{{ consul_python_bin }}-requests"
+  Debian-11:
+    - "{{ consul_python_bin }}-requests"
+  Debian-10:
+    - "{{ consul_python_bin }}-requests"
+  Debian-9:
+    - "{{ consul_python_bin }}-requests"
+
+consul_python_pip_required_packages_by_os:
+  Debian-12: []
+  Debian-11:
+    - python-consul
+    - pyhcl
+  Debian-10:
+    - python-consul
+    - pyhcl
+  Debian-9:
+    - python-consul
+    - pyhcl

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ consul_datadir: "{{ consul_basedir }}/data"
 consul_domain: consul
 consul_datacenter: main
 consul_interface: "{{ ansible_default_ipv4.alias }}"
-consul_ip: "{{ hostvars[ansible_nodename]['ansible_' +consul_interface]['ipv4']['address'] }}"
+consul_ip: "{{ hostvars[ansible_nodename]['ansible_' + consul_interface]['ipv4']['address'] }}"
 consul_http_port: 8500
 consul_dns_port: 8600
 consul_grpc_port: 8502

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -23,11 +23,10 @@ RUN echo "deb http://archive.debian.org/debian/ {{ distro }} main contrib non-fr
     echo "deb http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv && \
 {% else %}
 RUN apt-get update && \
-    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv procps && \
 {% endif %}
+    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv procps && \
     apt-get clean
 
 # https://github.com/moby/moby/issues/28614#issuecomment-310581026

--- a/molecule/default/group_vars/agent.yml
+++ b/molecule/default/group_vars/agent.yml
@@ -7,15 +7,15 @@ consul_ui: true
 consul_enable_script_check: true
 
 consul_services_register:
-  - name: node exporter http home
+  - name: node_exporter_http_home
     port: 9100
     http: "http://localhost:9100"
     interval: "60s"
-  - name: node exporter http
+  - name: node_exporter_http
     port: 9100
     http: "http://localhost:9100/metrics"
     interval: "60s"
     timeout: "30s"
-  - name: node exporter script
+  - name: node_exporter_script
     script: "pgrep node_exporter"
     interval: "60s"

--- a/molecule/sanity_healthcheck/Dockerfile.j2
+++ b/molecule/sanity_healthcheck/Dockerfile.j2
@@ -23,11 +23,10 @@ RUN echo "deb http://archive.debian.org/debian/ {{ distro }} main contrib non-fr
     echo "deb http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv && \
 {% else %}
 RUN apt-get update && \
-    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv procps && \
 {% endif %}
+    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv procps && \
     apt-get clean
 
 # https://github.com/moby/moby/issues/28614#issuecomment-310581026

--- a/tasks/consul_acl.yml
+++ b/tasks/consul_acl.yml
@@ -27,12 +27,11 @@
 
 - name: Consul | Install consul_acl prerequisites
   ansible.builtin.apt:
-    name: "{{ consul_acl_required_libs }}"
+    name: "{{ consul_python_apt_required_packages }}"
 
 - name: Consul | Install consul_acl Python prerequisites
   ansible.builtin.pip:
-    name: "{{ consul_acl_python_required_packages }}"
-    virtualenv: "{{ consul_python_virtualenv_path if consul_python_virtualenv else omit }}"
+    name: "{{ consul_python_pip_required_packages }}"
 
 - name: Consul | Wait for Consul to start up
   ansible.builtin.wait_for:

--- a/tasks/consul_acl.yml
+++ b/tasks/consul_acl.yml
@@ -40,14 +40,14 @@
 
 - name: Consul | Create ACLs
   ansible.builtin.include_tasks: consul_acl_new.yml
-  when: not consul_acl_use_legacy
+  when: not consul_acl_use_legacy | bool
   tags:
     - configure
     - acl
 
 - name: Consul | Create ACLs (legacy)
   ansible.builtin.include_tasks: consul_acl_legacy.yml
-  when: consul_acl_use_legacy
+  when: consul_acl_use_legacy | bool
   tags:
     - configure
     - acl_legacy

--- a/tasks/consul_acl_legacy.yml
+++ b/tasks/consul_acl_legacy.yml
@@ -8,8 +8,6 @@
     rules: "{{ item.value.rules }}"
     mgmt_token: "{{ consul_acl_master_token }}"
     host: "{{ consul_server_nodes | first }}"
-  vars:
-    ansible_python_interpreter: "{{ consul_python_virtualenv_path + '/bin/python' if consul_python_virtualenv else consul_python_bin }}"
   notify: Restart consul
   with_dict: "{{ consul_acl_configuration_list }}"
   no_log: true

--- a/tasks/consul_acl_new.yml
+++ b/tasks/consul_acl_new.yml
@@ -9,8 +9,6 @@
   notify: Restart consul
   with_items: "{{ consul_acl_policies }}"
   no_log: true
-  vars:
-    ansible_python_interpreter: "{{ consul_python_virtualenv_path + '/bin/python' if consul_python_virtualenv else consul_python_bin }}"
 
 - name: Consul | Create token
   community.general.consul_token:
@@ -22,5 +20,3 @@
   notify: Restart consul
   with_items: "{{ consul_acl_tokens }}"
   no_log: true
-  vars:
-    ansible_python_interpreter: "{{ consul_python_virtualenv_path + '/bin/python' if consul_python_virtualenv else consul_python_bin }}"

--- a/tasks/consul_acl_new.yml
+++ b/tasks/consul_acl_new.yml
@@ -9,6 +9,7 @@
   notify: Restart consul
   with_items: "{{ consul_acl_policies }}"
   no_log: true
+  tags: "{{ 'skip_ansible_lint' if consul_acl_use_legacy | bool else [] }}"
 
 - name: Consul | Create token
   community.general.consul_token:
@@ -20,3 +21,4 @@
   notify: Restart consul
   with_items: "{{ consul_acl_tokens }}"
   no_log: true
+  tags: "{{ 'skip_ansible_lint' if consul_acl_use_legacy | bool else [] }}"

--- a/tasks/consul_services_registration.yml
+++ b/tasks/consul_services_registration.yml
@@ -6,7 +6,7 @@
     - "{{ consul_services_register }}"
 
 - name: Consul | Register services
-  community.general.consul:
+  consul:
     service_name: "{{ item.name }}"
     service_port: "{{ item.port | default(omit) }}"
     service_address: "{{ item.service_address | default(omit) }}"  # In case the service is not in the local host

--- a/tasks/consul_services_registration.yml
+++ b/tasks/consul_services_registration.yml
@@ -6,7 +6,7 @@
     - "{{ consul_services_register }}"
 
 - name: Consul | Register services
-  consul:
+  ansible.builtin.consul:  # noqa fqcn[canonical]
     service_name: "{{ item.name }}"
     service_port: "{{ item.port | default(omit) }}"
     service_address: "{{ item.service_address | default(omit) }}"  # In case the service is not in the local host

--- a/tasks/consul_services_registration.yml
+++ b/tasks/consul_services_registration.yml
@@ -22,8 +22,6 @@
   no_log: true
   with_items:
     - "{{ consul_services_register }}"
-  vars:
-    ansible_python_interpreter: "{{ consul_python_virtualenv_path + '/bin/python' if consul_python_virtualenv else consul_python_bin }}"
 
 # Temporary, until consul state=absent is fixed
 - name: Consul | De-register services

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,26 +1,13 @@
 ---
-- name: Consul | Install dependencies
+- name: Consul | Install dependencies (APT)
   ansible.builtin.apt:
-    pkg: "{{ consul_required_libs }}"
+    pkg: "{{ consul_apt_required_packages + consul_python_apt_required_packages }}"
     update_cache: true
     cache_valid_time: 600
 
-- name: Consul | Install virtualenv dependencies
-  ansible.builtin.apt:
-    pkg: "{{ consul_virtualenv_required_libs }}"
-    update_cache: true
-    cache_valid_time: 600
-  when: consul_python_virtualenv
-
-- name: Consul | Create python virtualenv
-  ansible.builtin.command: "{{ consul_python_bin }} -m virtualenv {{ consul_python_virtualenv_path }}"
-  changed_when: false
-  when: consul_python_virtualenv
-
-- name: Consul | Install python dependencies
+- name: Consul | Install Python dependencies (PIP)
   ansible.builtin.pip:
-    name: "{{ consul_required_python_libs }}"
-    virtualenv: "{{ consul_python_virtualenv_path if consul_python_virtualenv else omit }}"
+    name: "{{ consul_python_pip_required_packages }}"
 
 - name: Consul | Ensure Consul group
   ansible.builtin.group:

--- a/tasks/service_healthcheck.yml
+++ b/tasks/service_healthcheck.yml
@@ -8,7 +8,7 @@
   block:
     - name: Consul | Check that web server is available
       vars:
-        timeout: "{{ item.timeout | default(omit) }}"
+        timeout: "{{ item.timeout | default(omit) }}"  # noqa var-naming[no-reserved]
         timeout_unit: "{{ timeout[-1] }}"
         timeout_has_suffix: "{{ timeout_unit in ['s', 'm'] }}"
         timeout_seconds: "{{ timeout[:-1] }}"


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

* Drop support for Python virtualenvs to avoid errors if `ansible_python_interpreter` is overridden.
* Add granular control over dependency installation based on OS version.


### Benefits

<!-- What benefits will be realized by the code change? -->

* The role works if `ansible_python_interpreter` variable is overridden by "include" statements (`include_vars`, `include_tasks`).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
N/A


### Applicable Issues

<!-- Enter any applicable Issues here -->

#106 