### PR TITLE
Feature/109 Add suport to uninstall Consul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## Unreleased
 
+## [1.12.0](https://github.com/idealista/consul_role/tree/1.12.0) (2025-04-23)
+### [Full Changelog](https://github.com/idealista/consul_role/compare/1.11.0...1.12.0)
+### Added
+- *[#106](https://github.com/idealista/consul_role/issues/109) Add support to uninstall Consul* @ommarmol
+### Fixed
+### Deprecated
+### Added
+
 ## [1.11.0](https://github.com/idealista/consul_role/tree/1.11.0) (2025-03-12)
 ### [Full Changelog](https://github.com/idealista/consul_role/compare/1.10.1...1.11.0)
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ To uninstall just set:
 ```yml
 consul_uninstall: true
 ```
+Keep in mind that the following files will be removed when uninstalling:
+```
+/etc/rsyslog.d/consul.conf
+/etc/logrotate.d/consul
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,16 @@ Use in a playbook:
 ## Usage
 
 Look to the defaults properties file (`defaults/main.yml`) to see the possible configuration properties.
+
 Logging uses rsyslog by default. It can be changed by overriding the `consul_service_log_output` variable. It can be changed to `journal` or other options seen at the StandardOutput and StandardError sections in:
  * [Debian 9 systemd docs](https://manpages.debian.org/stretch/systemd/systemd.exec.5.en.html)
  * [Debian 10, 11 and 12 systemd docs](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardOutput=)
+
+To uninstall just set:
+```yml
+consul_uninstall: true
+```
+
 ## Testing
 
 ```sh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ consul_nodename: "{{ ansible_nodename }}"
 consul_service_private_tmp: "{{ private_tmp_service | default(false) }}"
 
 consul_force_install: false
+consul_uninstall: false
 
 # Maximum number of files limit
 consul_max_files: 32768

--- a/molecule/uninstall/Dockerfile.j2
+++ b/molecule/uninstall/Dockerfile.j2
@@ -1,0 +1,34 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+# install minimal packages for debian slim images
+{% set python = "python" %}
+{% if item.image is regex('stretch') %}
+    {% set distro = "stretch" %}
+{% elif item.image is regex('(bullseye|bookworm)') %}
+    {% set python = "python3" %}
+{% endif %}
+
+{% if distro is defined %}
+RUN rm /etc/apt/sources.list.d/* || true
+RUN echo "deb http://archive.debian.org/debian/ {{ distro }} main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ {{ distro }} main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security {{ distro }}/updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian-security {{ distro }}/updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ {{ distro }}-backports main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
+{% else %}
+RUN apt-get update && \
+{% endif %}
+    apt-get install -y --force-yes {{ python }} sudo bash ca-certificates iproute2 systemd systemd-sysv procps && \
+    apt-get clean
+
+# https://github.com/moby/moby/issues/28614#issuecomment-310581026
+STOPSIGNAL SIGRTMIN+3
+RUN systemctl set-default multi-user.target

--- a/molecule/uninstall/converge.yml
+++ b/molecule/uninstall/converge.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Converge | Node exporter
+  hosts: consulagent
+  roles:
+    - node_exporter
+
+- name: Converge | Consul
+  hosts: consul
+  gather_facts: true
+  roles:
+    - role: rsyslog
+    - role: "{{ 'idealista.consul_role' if (ansible_version.string  is version('2.17.9', '>=')) else 'consul_role' }}"
+  post_tasks:
+    - name: Install net-tools for testing purposes
+      ansible.builtin.apt:
+        name: net-tools

--- a/molecule/uninstall/group_vars/agent.yml
+++ b/molecule/uninstall/group_vars/agent.yml
@@ -1,0 +1,21 @@
+---
+consul_agent: true
+# for goss testing
+consul_server: false
+consul_agent_services: true
+consul_ui: true
+consul_enable_script_check: true
+
+consul_services_register:
+  - name: node_exporter_http_home
+    port: 9100
+    http: "http://localhost:9100"
+    interval: "60s"
+  - name: node_exporter_http
+    port: 9100
+    http: "http://localhost:9100/metrics"
+    interval: "60s"
+    timeout: "30s"
+  - name: node_exporter_script
+    script: "pgrep node_exporter"
+    interval: "60s"

--- a/molecule/uninstall/group_vars/all.yml
+++ b/molecule/uninstall/group_vars/all.yml
@@ -1,0 +1,69 @@
+---
+consul_version: 1.2.3
+
+consul_interface: eth0
+
+consul_server_nodes:
+  - consulserver
+
+consul_domain: test
+consul_datacenter: test
+
+consul_acl: true
+consul_acl_default_policy: deny
+
+## ACL for discovery synchronization between servers
+consul_acl_policies:
+  - name: agent
+    rules: |
+      node "" {
+        policy = "write"
+      }
+      service "" {
+        policy = "write"
+      }
+  - name: anonymous
+    rules: |
+      key "" {
+        policy = "read"
+      }
+      node "" {
+        policy = "read"
+      }
+      service "" {
+        policy = "read"
+      }
+
+consul_acl_tokens:
+  - name: Agent
+    accessor_id: 972f8a50-9864-89fc-7db9-aadaafeaf538
+    policies:
+      - name: agent
+  ## ACL for anonymous UI reading
+  - name: Anonymous Token
+    accessor_id: 738ffff3-b313-e678-ad9a-fbd324afd5c4
+    policies:
+      - name: anonymous
+
+consul_acl_configuration_list:
+  Agent:
+    token_type: client
+    token: "{{ consul_acl_agent_token }}"
+    rules:
+      - node: ""
+        policy: write
+      - service: ""
+        policy: write
+  ## ACL for anonymous UI reading
+  Anonymous Token:
+    token_type: client
+    token: anonymous
+    rules:
+      - key: ""
+        policy: read
+      - node: ""
+        policy: read
+      - service: ""
+        policy: read
+
+node_exporter_private_tmp: false

--- a/molecule/uninstall/group_vars/server.yml
+++ b/molecule/uninstall/group_vars/server.yml
@@ -1,0 +1,3 @@
+---
+consul_server: true
+consul_ui: true

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -1,0 +1,62 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint: |
+  yamllint .
+  ansible-lint .
+
+platforms:
+  - name: consulserver
+    hostname: consulserver
+    image: ${MOLECULE_DISTRO:-debian:bookworm-slim}
+    networks:
+      - name: consul_network
+    stop_signal: 'RTMIN+3'
+    privileged: false
+    volumes:
+      - '/sys/fs/cgroup:/sys/fs/cgroup'
+    tmpfs:
+      - '/tmp'
+      - /run
+      - /run/lock
+    capabilities:
+      - SYS_ADMIN
+    published_ports:
+      - "8500:8500"
+    groups:
+      - consul
+      - server
+    command: '/lib/systemd/systemd'
+
+  - name: consulagent
+    hostname: consulagent
+    image: ${MOLECULE_DISTRO:-debian:bookworm-slim}
+    networks:
+      - name: consul_network
+    stop_signal: 'RTMIN+3'
+    privileged: false
+    tmpfs:
+      - '/tmp'
+      - /run
+      - /run/lock
+    volumes:
+      - '/sys/fs/cgroup:/sys/fs/cgroup'
+    capabilities:
+      - SYS_ADMIN
+    groups:
+      - consul
+      - agent
+    command: '/lib/systemd/systemd'
+
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: uninstall
+verifier:
+  name: ansible

--- a/molecule/uninstall/requirements.yml
+++ b/molecule/uninstall/requirements.yml
@@ -1,0 +1,8 @@
+---
+- src: https://github.com/idealista/prometheus_node_exporter_role.git
+  version: 6.1.0
+  name: node_exporter
+
+- src: https://github.com/idealista/rsyslog_role.git
+  version: 2.2.2
+  name: rsyslog

--- a/molecule/uninstall/side_effect.yml
+++ b/molecule/uninstall/side_effect.yml
@@ -6,5 +6,4 @@
   vars:
     consul_uninstall: true
   roles:
-    # - role: rsyslog
     - role: "{{ 'idealista.consul_role' if (ansible_version.string  is version('2.17.9', '>=')) else 'consul_role' }}"

--- a/molecule/uninstall/side_effect.yml
+++ b/molecule/uninstall/side_effect.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Side Effect | Consul
+  hosts: consulagent
+  gather_facts: true
+  vars:
+    consul_uninstall: true
+  roles:
+    # - role: rsyslog
+    - role: "{{ 'idealista.consul_role' if (ansible_version.string  is version('2.17.9', '>=')) else 'consul_role' }}"

--- a/molecule/uninstall/tests/test_consulagent.yml
+++ b/molecule/uninstall/tests/test_consulagent.yml
@@ -1,0 +1,34 @@
+service:
+  consul:
+    enabled: false
+    running: false
+
+file:
+  /opt/consul:
+    exists: false
+    filetype: directory
+    mode: "0755"
+    owner: consul
+    group: consul
+  /usr/bin/consul:
+    exists: false
+    filetype: symlink
+    linked-to: /opt/consul/bin/consul
+  /var/log/consul/consul.log:
+    exists: false
+
+user:
+  consul:
+    exists: false
+    groups:
+      - consul
+
+group:
+  consul:
+    exists: false
+
+port:
+  tcp6:8500:
+    listening: false
+  tcp6:8600:
+    listening: false

--- a/molecule/uninstall/tests/test_consulserver.yml
+++ b/molecule/uninstall/tests/test_consulserver.yml
@@ -1,0 +1,52 @@
+service:
+  consul:
+    enabled: true
+    running: true
+
+file:
+  /opt/consul:
+    exists: true
+    filetype: directory
+    mode: "0755"
+    owner: consul
+    group: consul
+  /usr/bin/consul:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/consul/bin/consul
+  /var/log/consul/consul.log:
+    exists: true
+
+user:
+  consul:
+    exists: true
+    groups:
+      - consul
+
+group:
+  consul:
+    exists: true
+
+port:
+  tcp:8300:
+    listening: true
+  tcp6:8500:
+    listening: true
+  tcp6:8600:
+    listening: true
+
+http:
+  http://localhost:8500/v1/acl/list:
+    status: 403
+  http://localhost:8500/v1/acl/list?token=master:
+    status: 200
+  http://localhost:8500/v1/catalog/node/consulagent:
+    status: 200
+    body:
+      - /^null$/
+
+command:
+  consul --version| head -n 1:
+    exit-status: 0
+    stdout:
+      - Consul v{{ consul_version }}

--- a/molecule/uninstall/verify.yml
+++ b/molecule/uninstall/verify.yml
@@ -1,0 +1,48 @@
+---
+- name: Verify
+  hosts: all
+  vars:
+    goss_version: v0.3.11
+    goss_arch: amd64
+    goss_dst: /usr/local/bin/goss
+    goss_sha256sum: 7a751c102abac61fd8dff45f87f36c3732cb5158e1414ab78e6877864fc2f7a4
+    goss_url:
+      "https://github.com/aelsabbahy/goss/releases/download/\
+      {{ goss_version }}/goss-linux-{{ goss_arch }}"
+    goss_test_directory: /tmp
+    goss_format: documentation
+
+  tasks:
+    - name: Download and install goss
+      get_url:
+        url: "{{ goss_url }}"
+        dest: "{{ goss_dst }}"
+        mode: 0755
+
+    - name: Copy tests to remote
+      template:
+        src: "{{ item }}"
+        dest: "{{ goss_test_directory }}/{{ item | basename }}"
+      with_fileglob:
+        - "{{ playbook_dir }}/tests/test_{{ ansible_fqdn }}.yml"
+
+    - name: Register test files
+      shell: "ls {{ goss_test_directory }}/test_{{ ansible_fqdn }}.yml"
+      register: test_files
+
+    - name: Execute Goss tests
+      command: "goss -g {{ item }} validate --format {{ goss_format }}"
+      register: test_results
+      with_items: "{{ test_files.stdout_lines }}"
+      ignore_errors: true
+
+    - name: Display details about the goss results
+      debug:
+        msg: "{{ item.stdout_lines }}"
+      with_items: "{{ test_results.results }}"
+
+    - name: Fail when tests fail
+      fail:
+        msg: "Goss failed to validate"
+      when: item.rc != 0
+      with_items: "{{ test_results.results }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,28 +9,40 @@
   ansible.builtin.import_tasks: install.yml
   tags:
     - install
-  when: consul_installed_version.rc != 0 or consul_force_install or consul_version not in consul_installed_version.stdout
+  when:
+    - consul_installed_version.rc != 0 or consul_force_install or consul_version not in consul_installed_version.stdout
+    - not consul_uninstall
 
 - name: Consul | Configure
   ansible.builtin.import_tasks: config.yml
   tags:
     - configure
+  when: not consul_uninstall
 
 - name: Consul | Service
   ansible.builtin.import_tasks: service.yml
   tags:
     - service
+  when: not consul_uninstall
 
 - name: Consul | Consul ACL
   ansible.builtin.include_tasks: consul_acl.yml
-  when: consul_acl
+  when: consul_acl and not consul_uninstall
   tags:
     - configure
     - acl
 
 - name: Consul | Consul services registration
   ansible.builtin.import_tasks: consul_services_registration.yml
-  when: consul_agent_services and consul_agent
+  when: consul_agent_services and consul_agent and not consul_uninstall
   tags:
     - configure
     - services
+
+- name: Consul | Uninstall
+  ansible.builtin.import_tasks: uninstall.yml
+  tags:
+    - uninstall
+  when:
+    - consul_uninstall
+    - not consul_installed_version.failed

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -32,6 +32,11 @@
   notify: Restart rsyslog
   when: consul_service_log_output == "syslog"
 
+- name: Consul | Remove logrotate consul config
+  ansible.builtin.file:
+    path: /etc/logrotate.d/consul
+    state: absent
+
 - name: Consul | Remove symlink
   ansible.builtin.file:
     path: /usr/bin/consul

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Consul | Leave consul cluser
-  ansible.builtin.shell: "{{ consul_bindir }}/consul leave -token={{ consul_acl_master_token }}"
+  ansible.builtin.command: "{{ consul_bindir }}/consul leave -token={{ consul_acl_master_token }}"
   changed_when: false
 
 - name: Consul | Stop and disable consul service

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,0 +1,55 @@
+---
+
+- name: Consul | Leave consul cluser
+  ansible.builtin.shell: "{{ consul_bindir }}/consul leave -token={{ consul_acl_master_token }}"
+  changed_when: false
+
+- name: Consul | Stop and disable consul service
+  ansible.builtin.systemd:
+    name: consul
+    state: stopped
+    enabled: no
+    daemon_reload: yes
+
+- name: Consul | Remove consul service
+  ansible.builtin.file:
+    path: /etc/systemd/system/consul.service
+    state: absent
+
+- name: Consul | Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: Consul | Remove base dir
+  ansible.builtin.file:
+    path: "{{ consul_basedir }}"
+    state: absent
+
+- name: Consul | Remove rsyslog consul config
+  ansible.builtin.file:
+    path: /etc/rsyslog.d/consul.conf
+    state: absent
+  notify: Restart rsyslog
+  when: consul_service_log_output == "syslog"
+
+- name: Consul | Remove symlink
+  ansible.builtin.file:
+    path: /usr/bin/consul
+    state: absent
+
+- name: Consul | Remove logdir
+  ansible.builtin.file:
+    path: "{{ consul_logdir }}"
+    state: absent
+
+- name: Consul | Remove Consul user
+  ansible.builtin.user:
+    name: "{{ consul_user }}"
+    group: "{{ consul_group }}"
+    createhome: no
+    state: absent
+
+- name: Consul | Remove Consul group
+  ansible.builtin.group:
+    name: "{{ consul_group }}"
+    state: absent


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

This PR adds the `consul_uninstall` variable to uninstall Consul.


### Benefits

If Consul is not needed, the role will revert the changes made during the installation of Consul.

### Possible Drawbacks

N/A

### Applicable Issues

#109 
